### PR TITLE
Revert "Grammar hacks (#70)"

### DIFF
--- a/test/pre-path-types.cooltt
+++ b/test/pre-path-types.cooltt
@@ -5,7 +5,7 @@
 -/
 
 def myrefl : {
-  (A : univ) (a : A) → (i : 𝕀) → sub A {∂ i} [∂ i => a]
+  (A : univ) (a : A) → (i : 𝕀) → sub A {∂ i} [i=0 => a | i=1 => a]
 } = {
   \A a i => a
 }


### PR DESCRIPTION
@Favonia I'm very sorry, but I had to revert this commit. I have made extensive changes to the grammar already in #17 and I realized after I merged your commit that it would be nearly impossible for me to resolve the conflict. 

But source location is a higher priority.